### PR TITLE
Update Demo to use a number version instead of null (Package.resolved)

### DIFF
--- a/Demo/SwiftUI/Demo.xcodeproj/project.pbxproj
+++ b/Demo/SwiftUI/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		27104ADC277128AE00E10E04 /* BambuserLiveVideoShoppingPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 27104ADB277128AE00E10E04 /* BambuserLiveVideoShoppingPlayer */; };
 		A922B1A526FB695500E235A1 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B18B26FB695500E235A1 /* DemoApp.swift */; };
 		A922B1A626FB695500E235A1 /* View+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B18E26FB695500E235A1 /* View+Alert.swift */; };
 		A922B1A726FB695500E235A1 /* AlertProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B18F26FB695500E235A1 /* AlertProvider.swift */; };
@@ -34,7 +35,6 @@
 		A99F288D2653D5AE0015B9D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A99F288C2653D5AE0015B9D2 /* Assets.xcassets */; };
 		A99F28902653D5AE0015B9D2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A99F288F2653D5AE0015B9D2 /* Preview Assets.xcassets */; };
 		A9AB8E8E26A95D1F008C0B76 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A9AB8E8D26A95D1F008C0B76 /* .swiftlint.yml */; };
-		A9C2309A26F2133D00961998 /* BambuserLiveVideoShoppingPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = A9C2309926F2133D00961998 /* BambuserLiveVideoShoppingPlayer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -87,7 +87,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9C2309A26F2133D00961998 /* BambuserLiveVideoShoppingPlayer in Frameworks */,
+				27104ADC277128AE00E10E04 /* BambuserLiveVideoShoppingPlayer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -253,7 +253,7 @@
 			);
 			name = Demo;
 			packageProductDependencies = (
-				A9C2309926F2133D00961998 /* BambuserLiveVideoShoppingPlayer */,
+				27104ADB277128AE00E10E04 /* BambuserLiveVideoShoppingPlayer */,
 			);
 			productName = Demo;
 			productReference = A99F28852653D5AC0015B9D2 /* Demo.app */;
@@ -284,7 +284,7 @@
 			);
 			mainGroup = A99F287C2653D5AC0015B9D2;
 			packageReferences = (
-				A9C2309826F2133D00961998 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */,
+				27104ADA277128AE00E10E04 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */,
 			);
 			productRefGroup = A99F28862653D5AC0015B9D2 /* Products */;
 			projectDirPath = "";
@@ -546,20 +546,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		A9C2309826F2133D00961998 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */ = {
+		27104ADA277128AE00E10E04 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bambuser/bambuser-livevideoshoppingplayer-sdk-ios.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		A9C2309926F2133D00961998 /* BambuserLiveVideoShoppingPlayer */ = {
+		27104ADB277128AE00E10E04 /* BambuserLiveVideoShoppingPlayer */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A9C2309826F2133D00961998 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */;
+			package = 27104ADA277128AE00E10E04 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */;
 			productName = BambuserLiveVideoShoppingPlayer;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Demo/SwiftUI/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/SwiftUI/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "BambuserLiveVideoShoppingPlayer",
         "repositoryURL": "https://github.com/bambuser/bambuser-livevideoshoppingplayer-sdk-ios.git",
         "state": {
-          "branch": "master",
-          "revision": "d6f19ec80fda23e442a205404b448620f78eefb5",
-          "version": null
+          "branch": null,
+          "revision": "db783b40cc23d9471b2f4588c3ab92f0d2b87551",
+          "version": "0.7.0"
         }
       }
     ]

--- a/Demo/UIKit/Demo.xcodeproj/project.pbxproj
+++ b/Demo/UIKit/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		27104ADF277128E000E10E04 /* BambuserLiveVideoShoppingPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 27104ADE277128E000E10E04 /* BambuserLiveVideoShoppingPlayer */; };
 		A922B1CD26FB6A5300E235A1 /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B1C326FB6A5300E235A1 /* PlayerViewController.swift */; };
 		A922B1CE26FB6A5300E235A1 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B1C426FB6A5300E235A1 /* HomeViewController.swift */; };
 		A922B1CF26FB6A5300E235A1 /* HomeTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B1C626FB6A5300E235A1 /* HomeTextFieldCell.swift */; };
@@ -20,7 +21,6 @@
 		A922B1DC26FB6A5F00E235A1 /* UIImage+Demo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B1D826FB6A5F00E235A1 /* UIImage+Demo.swift */; };
 		A922B1DD26FB6A5F00E235A1 /* DemoSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B1D926FB6A5F00E235A1 /* DemoSettings.swift */; };
 		A95D6750270DCEED0018A75B /* UIViewController+Demo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D674F270DCEED0018A75B /* UIViewController+Demo.swift */; };
-		A9C2309D26F2139200961998 /* BambuserLiveVideoShoppingPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = A9C2309C26F2139200961998 /* BambuserLiveVideoShoppingPlayer */; };
 		A9C328622654105F003B356A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9C328612654105F003B356A /* Assets.xcassets */; };
 		A9C328652654105F003B356A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A9C328632654105F003B356A /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -64,7 +64,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9C2309D26F2139200961998 /* BambuserLiveVideoShoppingPlayer in Frameworks */,
+				27104ADF277128E000E10E04 /* BambuserLiveVideoShoppingPlayer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -179,7 +179,7 @@
 			);
 			name = Demo;
 			packageProductDependencies = (
-				A9C2309C26F2139200961998 /* BambuserLiveVideoShoppingPlayer */,
+				27104ADE277128E000E10E04 /* BambuserLiveVideoShoppingPlayer */,
 			);
 			productName = Demo;
 			productReference = A9C328552654105E003B356A /* Demo.app */;
@@ -210,7 +210,7 @@
 			);
 			mainGroup = A9C3284C2654105E003B356A;
 			packageReferences = (
-				A9C2309B26F2139200961998 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */,
+				27104ADD277128E000E10E04 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */,
 			);
 			productRefGroup = A9C328562654105E003B356A /* Products */;
 			projectDirPath = "";
@@ -469,20 +469,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		A9C2309B26F2139200961998 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */ = {
+		27104ADD277128E000E10E04 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bambuser/bambuser-livevideoshoppingplayer-sdk-ios.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		A9C2309C26F2139200961998 /* BambuserLiveVideoShoppingPlayer */ = {
+		27104ADE277128E000E10E04 /* BambuserLiveVideoShoppingPlayer */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = A9C2309B26F2139200961998 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */;
+			package = 27104ADD277128E000E10E04 /* XCRemoteSwiftPackageReference "bambuser-livevideoshoppingplayer-sdk-ios" */;
 			productName = BambuserLiveVideoShoppingPlayer;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Demo/UIKit/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/UIKit/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "BambuserLiveVideoShoppingPlayer",
         "repositoryURL": "https://github.com/bambuser/bambuser-livevideoshoppingplayer-sdk-ios.git",
         "state": {
-          "branch": "master",
-          "revision": "d6f19ec80fda23e442a205404b448620f78eefb5",
-          "version": null
+          "branch": null,
+          "revision": "db783b40cc23d9471b2f4588c3ab92f0d2b87551",
+          "version": "0.7.0"
         }
       }
     ]


### PR DESCRIPTION
Update the Package.resolved of Demos project to use new versions. I was trying to test the `0.7` and figured out the projects were using `0.6`.